### PR TITLE
Fixes valid M3U checking

### DIFF
--- a/src/m3u-parser.ts
+++ b/src/m3u-parser.ts
@@ -88,7 +88,7 @@ export class M3uParser {
   }
 
   private static isValidM3u(firstLine: string[]): boolean {
-    return firstLine[0].replace('\n', '') === M3uDirectives.EXTM3U;
+    return firstLine[0].startsWith(M3uDirectives.EXTM3U);
   }
 
   static parse(m3uString: string): M3uPlaylist {


### PR DESCRIPTION
Some streams don't place the `#EXTM3U` directive on its own line. This checks if the first line starts with the directive, allowing all valid M3U streams to pass.