### PR TITLE
fix: ignore empty attributes

### DIFF
--- a/src/m3u-generator.ts
+++ b/src/m3u-generator.ts
@@ -35,8 +35,8 @@ export class M3uGenerator {
    * @private
    */
   private static getMedia(media: M3uMedia): string {
-    const attributesString =  this.getAttributes(media.attributes);
-    const info = this.shouldAddInfoDirective(media, attributesString) ? `${M3uDirectives.EXTINF}:${media.duration} ${attributesString},${media.name}` : null;
+    const attributesString = this.getAttributes(media.attributes);
+    const info = this.shouldAddInfoDirective(media, attributesString) ? `${M3uDirectives.EXTINF}:${media.duration}${attributesString},${media.name}` : null;
     const group = media.group ? `${M3uDirectives.EXTGRP}:${media.group}` : null;
     return [info, group, media.location].filter(item => item).join('\n');
   }
@@ -48,7 +48,8 @@ export class M3uGenerator {
    * @private
    */
   private static getAttributes(attributes: M3uAttributes): string {
-    return Object.keys(attributes).map(key => `${key}="${attributes[key]}"`).join(' ');
+    const keys = Object.keys(attributes);
+    return keys.length ? ' ' + keys.map(key => `${key}="${attributes[key]}"`).join(' ') : '';
   }
 
   /**

--- a/src/m3u-parser.ts
+++ b/src/m3u-parser.ts
@@ -115,7 +115,8 @@ export class M3uParser {
 
   /**
    * Parse is static method to parse m3u playlist string into m3u playlist object.
-   * Playlist need to contains #EXTM3U directive on first line.
+   * Playlist need to contain #EXTM3U directive on first line.
+   * All lines are trimmed and blank ones are removed.
    * @param m3uString - whole m3u playlist string
    * @returns parsed m3u playlist object
    * @example
@@ -125,7 +126,12 @@ export class M3uParser {
    * ```
    */
   static parse(m3uString: string): M3uPlaylist {
-    const lines = m3uString.split('\n').filter(item => item);
+    if (!m3uString) {
+      throw new Error(`m3uString can't be null!`);
+    }
+
+    const lines = m3uString.split('\n').map(item => item.trim()).filter(item => item != '');
+
     if (!this.isValidM3u(lines)) {
       throw new Error(`Missing ${M3uDirectives.EXTM3U} directive!`);
     }

--- a/src/m3u-parser.ts
+++ b/src/m3u-parser.ts
@@ -18,11 +18,14 @@ export class M3uParser {
    * @private
    */
   private static getAttributes(attributesString: string): M3uAttributes {
-    const attributeValuePair = attributesString.split('" ');
     const attributes: M3uAttributes = new M3uAttributes();
+    if (!attributesString) {
+      return attributes;
+    }
+    const attributeValuePair = attributesString.split('" ');
     attributeValuePair.forEach((item) => {
       const [key, value] = item.split('="');
-      attributes[key] = value.replace('"', '');
+      attributes[key] = value ? value.replace('"', '') : value;
     });
     return attributes;
   }
@@ -39,8 +42,9 @@ export class M3uParser {
     media.name = trackInformation.substring(lastCommaIndex + 1);
 
     const firstSpaceIndex = durationAttributes.indexOf(' ');
-    media.duration = Number(durationAttributes.substring(0, firstSpaceIndex));
-    const attributes = durationAttributes.substring(firstSpaceIndex + 1);
+    const durationEndIndex = firstSpaceIndex > 0 ? firstSpaceIndex : durationAttributes.length;
+    media.duration = Number(durationAttributes.substring(0, durationEndIndex));
+    const attributes = durationAttributes.substring(durationEndIndex + 1);
 
     media.attributes = this.getAttributes(attributes);
   }

--- a/src/m3u-parser.ts
+++ b/src/m3u-parser.ts
@@ -25,7 +25,10 @@ export class M3uParser {
     const attributeValuePair = attributesString.split('" ');
     attributeValuePair.forEach((item) => {
       const [key, value] = item.split('="');
-      attributes[key] = value ? value.replace('"', '') : value;
+      if (!value) {
+        throw new Error(`Attribute value can't be null!`);
+      }
+      attributes[key] = value.replace('"', '');
     });
     return attributes;
   }

--- a/src/m3u-parser.ts
+++ b/src/m3u-parser.ts
@@ -25,7 +25,7 @@ export class M3uParser {
     const attributeValuePair = attributesString.split('" ');
     attributeValuePair.forEach((item) => {
       const [key, value] = item.split('="');
-      if (!value) {
+      if (value == null) {
         throw new Error(`Attribute value can't be null!`);
       }
       attributes[key] = value.replace('"', '');

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -1,9 +1,10 @@
 import {M3uMedia, M3uParser, M3uPlaylist} from "../src";
-import {complex, extGroupDirectiveOrder} from "./test-m3u";
+import {complex, extGroupDirectiveOrder, attributes} from "./test-m3u";
 
 describe('Parse and generate test', () => {
     it('should be same as original after parse and generate', () => {
         expect(M3uParser.parse(complex).getM3uString()).toEqual(complex);
+        expect(M3uParser.parse(attributes).getM3uString()).toEqual(attributes);
     });
 
     it('should be parsed when random order of #EXTGRP directive is present', () => {

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -23,4 +23,10 @@ describe('Parse and generate test', () => {
         playlist.medias.push(new M3uMedia('location'));
         expect(playlist.getM3uString()).toEqual('#EXTM3U\nlocation');
     });
+
+    it('should parse empty attributes as empty', () => {
+        const parsed = M3uParser.parse(attributes);
+        expect(Object.keys(parsed.medias[0].attributes)).toEqual([]);
+        expect(Object.keys(parsed.medias[1].attributes)).not.toEqual([]);
+    });
 });

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -24,7 +24,7 @@ describe('Parse and generate test', () => {
         expect(playlist.getM3uString()).toEqual('#EXTM3U\nlocation');
     });
 
-    it('should parse empty attributes as empty', () => {
+    it('should be parsed when no attributes are present', () => {
         const parsed = M3uParser.parse(attributes);
         expect(Object.keys(parsed.medias[0].attributes)).toEqual([]);
         expect(Object.keys(parsed.medias[1].attributes)).not.toEqual([]);

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -1,10 +1,10 @@
 import {M3uMedia, M3uParser, M3uPlaylist} from "../src";
-import {complex, extGroupDirectiveOrder, attributes} from "./test-m3u";
+import {complex, extGroupDirectiveOrder, emptyAttributes, invalidAttributes} from "./test-m3u";
 
 describe('Parse and generate test', () => {
     it('should be same as original after parse and generate', () => {
         expect(M3uParser.parse(complex).getM3uString()).toEqual(complex);
-        expect(M3uParser.parse(attributes).getM3uString()).toEqual(attributes);
+        expect(M3uParser.parse(emptyAttributes).getM3uString()).toEqual(emptyAttributes);
     });
 
     it('should be parsed when random order of #EXTGRP directive is present', () => {
@@ -25,12 +25,16 @@ describe('Parse and generate test', () => {
     });
 
     it('should be parsed when no attributes are present', () => {
-        const parsed = M3uParser.parse(attributes);
+        const parsed = M3uParser.parse(emptyAttributes);
         expect(Object.keys(parsed.medias[0].attributes)).toEqual([]);
         expect(Object.keys(parsed.medias[1].attributes)).not.toEqual([]);
     });
 
     it('should raise exception when parsing invalid m3u string', () => {
         expect(() => M3uParser.parse('')).toThrow(new Error(`m3uString can't be null!`));
+    });
+
+    it('should raise exception when parsing invalid attribute string', () => {
+        expect(() => M3uParser.parse(invalidAttributes)).toThrow(new Error(`Attribute value can't be null!`));
     });
 });

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -29,4 +29,8 @@ describe('Parse and generate test', () => {
         expect(Object.keys(parsed.medias[0].attributes)).toEqual([]);
         expect(Object.keys(parsed.medias[1].attributes)).not.toEqual([]);
     });
+
+    it('should raise exception when parsing invalid m3u string', () => {
+        expect(() => M3uParser.parse('')).toThrow(new Error(`m3uString can't be null!`));
+    });
 });

--- a/test/test-m3u.ts
+++ b/test/test-m3u.ts
@@ -17,3 +17,11 @@ http://iptv.test1.com/playlist.m3u8
 #EXTGRP:Test TV group 2
 #EXTINF:100 tvg-id="Test tv 2" tvg-country="SK" tvg-language="SK" tvg-logo="logo2.png" group-title="Test2",Test tv 2 [SK]
 http://iptv.test2.com/playlist.m3u8`;
+
+export const attributes = `#EXTM3U
+#EXTINF:-1,Test tv 1 [CZ]
+#EXTGRP:Test TV group 1
+http://iptv.test1.com/playlist.m3u8
+#EXTINF:100 tvg-id="Test tv 2" tvg-country="SK" tvg-language="SK" tvg-logo="logo2.png" group-title="Test2",Test tv 2 [SK]
+#EXTGRP:Test TV group 2
+http://iptv.test2.com/playlist.m3u8`;

--- a/test/test-m3u.ts
+++ b/test/test-m3u.ts
@@ -18,10 +18,18 @@ http://iptv.test1.com/playlist.m3u8
 #EXTINF:100 tvg-id="Test tv 2" tvg-country="SK" tvg-language="SK" tvg-logo="logo2.png" group-title="Test2",Test tv 2 [SK]
 http://iptv.test2.com/playlist.m3u8`;
 
-export const attributes = `#EXTM3U
+export const emptyAttributes = `#EXTM3U
 #EXTINF:-1,Test tv 1 [CZ]
 #EXTGRP:Test TV group 1
 http://iptv.test1.com/playlist.m3u8
 #EXTINF:100 tvg-id="Test tv 2" tvg-country="SK" tvg-language="SK" tvg-logo="logo2.png" group-title="Test2",Test tv 2 [SK]
+#EXTGRP:Test TV group 2
+http://iptv.test2.com/playlist.m3u8`;
+
+export const invalidAttributes = `#EXTM3U
+#EXTINF:-1 tvg-id="Test tv 1" tvg-country="CZ" tvg-language="CS" tvg-logo="logo1.png" group-title="Test1" unknown=,Test tv 1 [CZ]
+#EXTGRP:Test TV group 1
+http://iptv.test1.com/playlist.m3u8
+#EXTINF:100 unknown=" tvg-id="Test tv 2" tvg-country="SK" tvg-language="SK" tvg-logo="logo2.png" group-title="Test2",Test tv 2 [SK]
 #EXTGRP:Test TV group 2
 http://iptv.test2.com/playlist.m3u8`;


### PR DESCRIPTION
supersedes #4 
- now with tests
- throws on invalid attribute
- doesn't create a space for empty attributes when generating