### PR TITLE
fix: Allow KODIPROPs with multiple '=' signs

### DIFF
--- a/src/m3u-parser.ts
+++ b/src/m3u-parser.ts
@@ -102,7 +102,8 @@ export class M3uParser {
         break;
       }
       case M3uDirectives.KODIPROP: {
-        const [key, value] = trackInformation.split('=');
+        const [key, ...valueParts] = trackInformation.split('=');
+        const value = valueParts.join('='); // in case value contains '=', ie. '#KODIPROP:inputstream.adaptive.license_key=https://example.com/license.php?id=example'
 
         if(!media.kodiProps) {
           media.kodiProps = new Map<string, string>();

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -128,7 +128,7 @@ describe('Parse and generate test', () => {
         expect(playlist.medias[0].kodiProps).toEqual(new Map([
             [ 'inputstream.adaptive.manifest_type', 'm3u8' ],
             [ 'inputstream.adaptive.license_type', 'org.w3.clearkey' ],
-            [ 'inputstream.adaptive.license_key', 'test' ]
+            [ 'inputstream.adaptive.license_key', 'https://example.com/license.php?id=example' ]
         ]));
     });
 
@@ -146,7 +146,7 @@ describe('Parse and generate test', () => {
         media.kodiProps = new Map([
             [ 'inputstream.adaptive.manifest_type', 'm3u8' ],
             [ 'inputstream.adaptive.license_type', 'org.w3.clearkey' ],
-            [ 'inputstream.adaptive.license_key', 'test' ]
+            [ 'inputstream.adaptive.license_key', 'https://example.com/license.php?id=example' ]
         ]);
         const playlist = new M3uPlaylist();
         playlist.medias.push(media);

--- a/test/test-m3u.ts
+++ b/test/test-m3u.ts
@@ -54,7 +54,7 @@ export const playlistWithKodiProps = `#EXTM3U
 #EXTGRP:Test TV group 1
 #KODIPROP:inputstream.adaptive.manifest_type=m3u8
 #KODIPROP:inputstream.adaptive.license_type=org.w3.clearkey
-#KODIPROP:inputstream.adaptive.license_key=test
+#KODIPROP:inputstream.adaptive.license_key=https://example.com/license.php?id=example
 http://iptv.test1.com/playlist.m3u8`
 
 export const playlistWithExtraProps = `#EXTM3U url-tvg="http://example.com/tvg.xml" url-logo="http://path/to/icons/root/"


### PR DESCRIPTION
I had a use case with a m3u8 file using the following format to specify an external license_key for KODI:
`#KODIPROP:inputstream.adaptive.license_key=https://example.com/license.php?id=example`

The current implementation uses
`const [key, value] = trackInformation.split('=');`
in order to get the key, value pair.

In this example the parsed data would be `value = https://example.com/license.php?id`, removing everything after the second '='.

The current pull request fixes this issue, and the corresponding test has also been updated.