### PR TITLE
Correctly parse EXTINF name with comma

### DIFF
--- a/src/m3u-parser.ts
+++ b/src/m3u-parser.ts
@@ -64,9 +64,9 @@ export class M3uParser {
    * @private
    */
   private processMedia(trackInformation: string, media: M3uMedia): void {
-    const lastCommaIndex = trackInformation.lastIndexOf(',');
-    const durationAttributes = trackInformation.substring(0, lastCommaIndex);
-    media.name = trackInformation.substring(lastCommaIndex + 1);
+    const firstCommaIndex = trackInformation.indexOf(',');
+    const durationAttributes = trackInformation.substring(0, firstCommaIndex);
+    media.name = trackInformation.substring(firstCommaIndex + 1);
 
     const firstSpaceIndex = durationAttributes.indexOf(' ');
     const durationEndIndex = firstSpaceIndex > 0 ? firstSpaceIndex : durationAttributes.length;

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -10,7 +10,9 @@ import {
     playlistWithExtraHTTPHeaders,
     playlistWithKodiProps,
     playlistWithExtraProps,
-    invalidExtM3uAttributes, playlistWithCustomDirectives
+    invalidExtM3uAttributes,
+    playlistWithCustomDirectives,
+    commaNames
 } from "./test-m3u";
 
 describe('Parse and generate test', () => {
@@ -23,6 +25,7 @@ describe('Parse and generate test', () => {
 
     it('should be same as original after parse and generate', () => {
         expect(parser.parse(complex).getM3uString()).toEqual(complex);
+        expect(parser.parse(commaNames).getM3uString()).toEqual(commaNames);
         expect(parser.parse(emptyAttributes).getM3uString()).toEqual(emptyAttributes);
     });
 

--- a/test/test-m3u.ts
+++ b/test/test-m3u.ts
@@ -75,3 +75,10 @@ export const playlistWithCustomDirectives = `#EXTM3U
 http://iptv.test1.com/playlist.m3u8
 #EXTCUSTOMMEDIA:MEDIA2
 http://iptv.test1.com/playlist2.m3u8`
+
+
+export const commaNames = `#EXTM3U
+#PLAYLIST:Test Commas
+#EXTINF:-1,TiNGL - Pitch, Please
+#EXTART:Pitch, Please
+/Podcasts/somefile.mp3`


### PR DESCRIPTION
Fix for this seemed pretty straightforward so PR for the issue I opened.

Change EXTINF parsing to split on first, not last, comma
Add test case for names with comma

Resolves #14 